### PR TITLE
Investigate 404 error after deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ],
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}
+


### PR DESCRIPTION
Add a root-level `vercel.json` to configure Vercel to deploy the `frontend` application with SPA fallback.

This resolves 404 errors on client-side routes by ensuring Vercel builds the correct project and routes all unmatched requests to `index.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-71dcc9f6-b536-4ba3-9856-1fb61d8e0803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-71dcc9f6-b536-4ba3-9856-1fb61d8e0803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

